### PR TITLE
fix call to close method

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -153,7 +153,7 @@ function simple_dialogs.load_dialog_from_file(npcself,modname,dialogfilename)
 	local file = io.open(minetest.get_modpath(modname).."/"..dialogfilename)
 	if file then
 		local dialogstr=file:read("*all")
-		file.close()
+		file:close()
 		simple_dialogs.load_dialog_from_string(npcself,dialogstr)
 	end
 end --load_dialog_from_file
@@ -781,7 +781,7 @@ function simple_dialogs.dialog_help(playername)
 		--minetest.log("simple_dialogs-> dh if file")
 		--local help
 		local helpstr=file:read("*all")
-		file.close()
+		file:close()
 		local formspec={
 		"formspec_version[4]",
 		"size[15,15]", 


### PR DESCRIPTION
The `file.close` calls cause a crash. The documented way to close a file is `file:close` ([1]).

[1] https://www.lua.org/pil/21.2.html